### PR TITLE
Adicionando demais cenários

### DIFF
--- a/exploring-kotlin-coroutines/src/gatling/kotlin/CreateApiComparison.kt
+++ b/exploring-kotlin-coroutines/src/gatling/kotlin/CreateApiComparison.kt
@@ -1,0 +1,40 @@
+import io.gatling.javaapi.core.CoreDsl.StringBody
+import io.gatling.javaapi.core.CoreDsl.constantConcurrentUsers
+import io.gatling.javaapi.core.CoreDsl.scenario
+import io.gatling.javaapi.core.Simulation
+import io.gatling.javaapi.http.HttpDsl.http
+import io.gatling.javaapi.http.HttpDsl.status
+
+class CreateApiComparison : Simulation() {
+
+    private val httpProtocol = http.baseUrl("http://localhost:8080")
+
+    private val endpointWithCoroutines = "/api/coroutine/create"
+    private val endpointWithoutCoroutines = "/api/create"
+
+
+    private val scenarioWithCoroutines = scenario("Test with Coroutines")
+        .exec(
+            http("Request with Coroutines")
+                .post(endpointWithCoroutines)
+                .body(StringBody("""{"status": "TODO"}"""))
+                .header("content-type", "application/json")
+                .check(status().shouldBe(200))
+        )
+
+    private val scenarioWithoutCoroutines = scenario("Test without Coroutines")
+        .exec(
+            http("Request without Coroutines")
+                .post(endpointWithoutCoroutines)
+                .body(StringBody("""{"status": "TODO"}"""))
+                .header("content-type", "application/json")
+                .check(status().shouldBe(200))
+        )
+
+    init {
+        setUp(
+            scenarioWithCoroutines.injectClosed(constantConcurrentUsers(100).during(30)),
+            scenarioWithoutCoroutines.injectClosed(constantConcurrentUsers(100).during(30))
+        ).protocols(httpProtocol)
+    }
+}

--- a/exploring-kotlin-coroutines/src/gatling/kotlin/DeleteApiComparison.kt
+++ b/exploring-kotlin-coroutines/src/gatling/kotlin/DeleteApiComparison.kt
@@ -1,0 +1,35 @@
+import io.gatling.javaapi.core.CoreDsl.constantConcurrentUsers
+import io.gatling.javaapi.core.CoreDsl.scenario
+import io.gatling.javaapi.core.Simulation
+import io.gatling.javaapi.http.HttpDsl.http
+import io.gatling.javaapi.http.HttpDsl.status
+
+class DeleteApiComparison : Simulation() {
+
+    private val httpProtocol = http.baseUrl("http://localhost:8080")
+
+    private val endpointWithCoroutines = "/api/coroutine/delete/3"
+    private val endpointWithoutCoroutines = "/api/delete/3"
+
+
+    private val scenarioWithCoroutines = scenario("Test with Coroutines")
+        .exec(
+            http("Request with Coroutines")
+                .delete(endpointWithCoroutines)
+                .check(status().`is`(200))
+        )
+
+    private val scenarioWithoutCoroutines = scenario("Test without Coroutines")
+        .exec(
+            http("Request without Coroutines")
+                .delete(endpointWithoutCoroutines)
+                .check(status().`is`(200))
+        )
+
+    init {
+        setUp(
+            scenarioWithCoroutines.injectClosed(constantConcurrentUsers(1).during(1)),
+            scenarioWithoutCoroutines.injectClosed(constantConcurrentUsers(1).during(1))
+        ).protocols(httpProtocol)
+    }
+}

--- a/exploring-kotlin-coroutines/src/gatling/kotlin/UpdateApiComparison.kt
+++ b/exploring-kotlin-coroutines/src/gatling/kotlin/UpdateApiComparison.kt
@@ -1,0 +1,40 @@
+import io.gatling.javaapi.core.CoreDsl.StringBody
+import io.gatling.javaapi.core.CoreDsl.constantConcurrentUsers
+import io.gatling.javaapi.core.CoreDsl.scenario
+import io.gatling.javaapi.core.Simulation
+import io.gatling.javaapi.http.HttpDsl.http
+import io.gatling.javaapi.http.HttpDsl.status
+
+class UpdateApiComparison : Simulation() {
+
+    private val httpProtocol = http.baseUrl("http://localhost:8080")
+
+    private val endpointWithCoroutines = "/api/coroutine/update/2"
+    private val endpointWithoutCoroutines = "/api/update/2"
+
+
+    private val scenarioWithCoroutines = scenario("Test with Coroutines")
+        .exec(
+            http("Request with Coroutines")
+                .put(endpointWithCoroutines)
+                .body(StringBody("""{"status": "COMPLETED"}"""))
+                .header("content-type", "application/json")
+                .check(status().shouldBe(200))
+        )
+
+    private val scenarioWithoutCoroutines = scenario("Test without Coroutines")
+        .exec(
+            http("Request without Coroutines")
+                .put(endpointWithoutCoroutines)
+                .body(StringBody("""{"status": "COMPLETED"}"""))
+                .header("content-type", "application/json")
+                .check(status().shouldBe(200))
+        )
+
+    init {
+        setUp(
+            scenarioWithCoroutines.injectClosed(constantConcurrentUsers(1).during(1)),
+            scenarioWithoutCoroutines.injectClosed(constantConcurrentUsers(1).during(1))
+        ).protocols(httpProtocol)
+    }
+}


### PR DESCRIPTION
This pull request adds new performance testing simulations for API endpoints using Gatling. The changes include creating scenarios for testing endpoints with and without Kotlin coroutines for create, delete, and update operations.

### New Gatling Simulations for API Testing:

* **Create API Comparison:**
  - Added a simulation class `CreateApiComparison` to test the create endpoint with and without coroutines.

* **Delete API Comparison:**
  - Added a simulation class `DeleteApiComparison` to test the delete endpoint with and without coroutines.

* **Update API Comparison:**
  - Added a simulation class `UpdateApiComparison` to test the update endpoint with and without coroutines.